### PR TITLE
Update to python3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Change log for gocept.jasmine
 
 - Migrate to Github.
 
+- Migrate to python3
+
 
 0.6 (2017-03-21)
 ================

--- a/src/gocept/jasmine/jasmine.py
+++ b/src/gocept/jasmine/jasmine.py
@@ -28,7 +28,7 @@ class TestApp(object):
         gocept.jasmine.resource.jasmine.need()
         return [
             '<html><head>Jasmine Tests</head><body>{}</body></html>'.format(
-                self.body)]
+                self.body).encode("utf-8")]
 
 
 class Layer(plone.testing.Layer):


### PR DESCRIPTION
I needed to encode a `str` so the tests would run in python3. Tested it with tox. 

```
[tox]
envlist = py27, py3
[testenv]
usedevelop = true
commands =
    py.test src -o python_files=test_jasmine.py --flake8 {posargs}
deps =
    pytest==4.6.5
    pytest-flake8
    gocept.pytestlayer
    .[test]
```